### PR TITLE
Bugfix/#18300  likvido app   pentest  azure blob shared key disclosure and a ssrf

### DIFF
--- a/src/version.props
+++ b/src/version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.1.22</Version>
+    <Version>1.1.23</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
#18300

This PR adds a check for the domain part in the URL passed to `GetBlobSasUriAsync`. We expect it to be an Azure Blob Storage link. If it's not, we'll throw an exception.