### PR TITLE
Likvido/Likvido.App#18850 - Throwing a more verbose error message when the queue name is not available

### DIFF
--- a/src/Likvido.Azure/Queue/QueueService.cs
+++ b/src/Likvido.Azure/Queue/QueueService.cs
@@ -81,6 +81,11 @@ namespace Likvido.Azure.Queue
             TimeSpan? timeToLive = null,
             CancellationToken cancellationToken = default)
         {
+            if (string.IsNullOrWhiteSpace(queueName))
+            {
+                throw new ArgumentException("Queue name cannot be null or empty, please check the configuration.", nameof(queueName));
+            }
+
             await new ResiliencePipelineBuilder()
                 .AddRetry(new RetryStrategyOptions
                 {


### PR DESCRIPTION
#18850

This PR updates the `SendMessageAsync` method so that it throws a meaningful error message when the queue name is not configured.
