### PR TITLE
Feature/#19675  likvido azure  do not force setting a public access policy on the blob storage containers

### DIFF
--- a/src/Likvido.Azure/Storage/AzureStorageService.cs
+++ b/src/Likvido.Azure/Storage/AzureStorageService.cs
@@ -78,11 +78,11 @@ namespace Likvido.Azure.Storage
         {
             content.Seek(0, SeekOrigin.Begin);
 
-            string duplicateAwareKey = key;
+            var duplicateAwareKey = key;
             if (!overwrite)
             {
-                duplicateAwareKey = (iteration > 0) ?
-                    $"{Path.GetDirectoryName(key).Replace('\\', '/')}/{Path.GetFileNameWithoutExtension(key)}({iteration.ToString()}){Path.GetExtension(key)}"
+                duplicateAwareKey = iteration > 0 ?
+                    $"{Path.GetDirectoryName(key)?.Replace('\\', '/')}/{Path.GetFileNameWithoutExtension(key)}({iteration.ToString()}){Path.GetExtension(key)}"
                     : key;
             }
 

--- a/src/Likvido.Azure/Storage/AzureStorageService.cs
+++ b/src/Likvido.Azure/Storage/AzureStorageService.cs
@@ -131,7 +131,7 @@ namespace Likvido.Azure.Storage
         public string GetBlobNameFromUri(Uri uri)
         {
             var path = HttpUtility.UrlDecode(uri.AbsolutePath);
-            var containerNameIndex = path.IndexOf(blobContainerClient.Name);
+            var containerNameIndex = path.IndexOf(blobContainerClient.Name, StringComparison.Ordinal);
 
             if (containerNameIndex >= 0)
             {

--- a/src/Likvido.Azure/Storage/AzureStorageService.cs
+++ b/src/Likvido.Azure/Storage/AzureStorageService.cs
@@ -26,24 +26,12 @@ namespace Likvido.Azure.Storage
 
         public async Task DeleteAsync(Uri uri)
         {
-            var absolutePath = uri.AbsolutePath;
-            if (absolutePath.StartsWith("/"))
-            {
-                absolutePath = absolutePath.Substring(1);
-            }
-
-            if (absolutePath.StartsWith(blobContainerClient.Name))
-            {
-                absolutePath = absolutePath.Substring(blobContainerClient.Name.Length + 1);
-            }
-
-            await DeleteAsync(absolutePath).ConfigureAwait(false);
+            await DeleteAsync(new BlobClient(uri)).ConfigureAwait(false);
         }
 
         public async Task DeleteAsync(string key)
         {
-            var blob = blobContainerClient.GetBlobClient(HttpUtility.UrlDecode(key));
-            await blob.DeleteIfExistsAsync().ConfigureAwait(false);
+            await DeleteAsync(blobContainerClient.GetBlobClient(HttpUtility.UrlDecode(key))).ConfigureAwait(false);
         }
 
         public IEnumerable<Uri> Find(string prefix)
@@ -125,6 +113,11 @@ namespace Likvido.Azure.Storage
             blobSasBuilder.SetPermissions(BlobSasPermissions.Read);
             var sasBlobToken = blobClient.GenerateSasUri(blobSasBuilder);
             return sasBlobToken.AbsoluteUri;
+        }
+
+        private static async Task DeleteAsync(BlobClient blobClient)
+        {
+            await blobClient.DeleteIfExistsAsync().ConfigureAwait(false);
         }
 
         private static async Task<MemoryStream> GetAsync(BlobClient blobClient)

--- a/src/Likvido.Azure/Storage/AzureStorageService.cs
+++ b/src/Likvido.Azure/Storage/AzureStorageService.cs
@@ -69,6 +69,21 @@ namespace Likvido.Azure.Storage
             return newBlob.Uri;
         }
 
+        public async Task<Uri> RenameAsync(string tempFileName, string fileName)
+        {
+            var existingBlob = blobContainerClient.GetBlobClient(tempFileName);
+
+            if (existingBlob == null || !await existingBlob.ExistsAsync().ConfigureAwait(false))
+            {
+                return null;
+            }
+
+            var newBlob = blobContainerClient.GetBlobClient(fileName);
+            await newBlob.StartCopyFromUriAsync(existingBlob.Uri).ConfigureAwait(false);
+
+            return newBlob.Uri;
+        }
+
         public Uri Set(string key, Stream content, bool overwrite = true, Dictionary<string, string> metadata = null)
         {
             return Set(key, content, overwrite, 0, metadata);
@@ -155,22 +170,6 @@ namespace Likvido.Azure.Storage
             var blobProperties = await blob.GetPropertiesAsync().ConfigureAwait(false);
 
             return blobProperties.Value.Metadata;
-        }
-
-        public async Task<Uri> RenameAsync(string tempFileName, string fileName)
-        {
-            var existingBlob = blobContainerClient.GetBlobClient(tempFileName);
-            if (existingBlob?.Exists())
-            {
-                var newBlob = blobContainerClient.GetBlobClient(fileName);
-                var blobObj = newBlob as BlobClient;
-                if (blobObj?.Exists())
-                {
-                    await blobObj.StartCopyFromUriAsync(existingBlob.Uri).ConfigureAwait(false);
-                }
-                return newBlob.Uri;
-            }
-            return null;
         }
 
         public async Task<Uri> SetAsync(string key, Stream content, string friendlyName = null, bool overwrite = true, Dictionary<string, string> metadata = null)

--- a/src/Likvido.Azure/Storage/AzureStorageService.cs
+++ b/src/Likvido.Azure/Storage/AzureStorageService.cs
@@ -114,18 +114,12 @@ namespace Likvido.Azure.Storage
 
         public async Task<MemoryStream> GetAsync(string blobName)
         {
-            try
-            {
-                var stream = new MemoryStream();
-                var blob = blobContainerClient.GetBlobClient(blobName);
-                await blob.DownloadToAsync(stream).ConfigureAwait(false);
-                stream.Position = 0;
-                return stream;
-            }
-            catch (Exception ex)
-            {
-                throw ex;
-            }
+            var stream = new MemoryStream();
+            var blob = blobContainerClient.GetBlobClient(blobName);
+            await blob.DownloadToAsync(stream).ConfigureAwait(false);
+            stream.Position = 0;
+
+            return stream;
         }
 
         public string GetBlobNameFromUri(Uri uri)

--- a/src/Likvido.Azure/Storage/AzureStorageService.cs
+++ b/src/Likvido.Azure/Storage/AzureStorageService.cs
@@ -23,7 +23,6 @@ namespace Likvido.Azure.Storage
             var blobServiceClient = new BlobServiceClient(storageConfiguration.ConnectionString);
             blobContainerClient = blobServiceClient.GetBlobContainerClient(containerName);
             blobContainerClient.CreateIfNotExists();
-            blobContainerClient.SetAccessPolicy(PublicAccessType.Blob);
         }
 
         public async Task DeleteAsync(Uri uri)

--- a/src/Likvido.Azure/Storage/AzureStorageService.cs
+++ b/src/Likvido.Azure/Storage/AzureStorageService.cs
@@ -89,6 +89,11 @@ namespace Likvido.Azure.Storage
             return Set(key, content, overwrite, 0, metadata);
         }
 
+        public async Task<Uri> SetAsync(string key, Stream content, string friendlyName = null, bool overwrite = true, Dictionary<string, string> metadata = null)
+        {
+            return await SetAsync(key, content, friendlyName, overwrite, 0, metadata).ConfigureAwait(false);
+        }
+
         public async Task<MemoryStream> GetAsync(Uri uri)
         {
             return await GetAsync(GetBlobNameFromUri(uri)).ConfigureAwait(false);
@@ -137,11 +142,6 @@ namespace Likvido.Azure.Storage
             var blobProperties = await blob.GetPropertiesAsync().ConfigureAwait(false);
 
             return blobProperties.Value.Metadata;
-        }
-
-        public async Task<Uri> SetAsync(string key, Stream content, string friendlyName = null, bool overwrite = true, Dictionary<string, string> metadata = null)
-        {
-            return await SetAsync(key, content, friendlyName, overwrite, 0, metadata).ConfigureAwait(false);
         }
 
         public async Task<string> GetBlobSasUriAsync(string url)

--- a/src/Likvido.Azure/Storage/AzureStorageService.cs
+++ b/src/Likvido.Azure/Storage/AzureStorageService.cs
@@ -185,11 +185,12 @@ namespace Likvido.Azure.Storage
         private async Task<Uri> SetAsync(string key, Stream content, string friendlyName = null, bool overwrite = true, int iteration = 0, Dictionary<string, string> metadata = null)
         {
             content.Seek(0, SeekOrigin.Begin);
-            string duplicateAwareKey = key;
+
+            var duplicateAwareKey = key;
             if (!overwrite)
             {
-                duplicateAwareKey = (iteration > 0) ?
-                    $"{Path.GetDirectoryName(key).Replace('\\', '/')}/{Path.GetFileNameWithoutExtension(key)}({iteration.ToString()}){Path.GetExtension(key)}"
+                duplicateAwareKey = iteration > 0 ?
+                    $"{Path.GetDirectoryName(key)?.Replace('\\', '/')}/{Path.GetFileNameWithoutExtension(key)}({iteration.ToString()}){Path.GetExtension(key)}"
                     : key;
             }
 

--- a/src/Likvido.Azure/Storage/AzureStorageService.cs
+++ b/src/Likvido.Azure/Storage/AzureStorageService.cs
@@ -22,7 +22,6 @@ namespace Likvido.Azure.Storage
 
             var blobServiceClient = new BlobServiceClient(storageConfiguration.ConnectionString);
             blobContainerClient = blobServiceClient.GetBlobContainerClient(containerName);
-            blobContainerClient.CreateIfNotExists();
         }
 
         public async Task DeleteAsync(Uri uri)

--- a/src/Likvido.Azure/Storage/AzureStorageService.cs
+++ b/src/Likvido.Azure/Storage/AzureStorageService.cs
@@ -57,13 +57,15 @@ namespace Likvido.Azure.Storage
         public Uri Rename(string tempFileName, string fileName)
         {
             var existingBlob = blobContainerClient.GetBlobClient(tempFileName);
+
             if (existingBlob?.Exists() == true)
             {
                 var newBlob = blobContainerClient.GetBlobClient(fileName);
-                var blobObj = newBlob as BlobClient;
-                blobObj?.StartCopyFromUri(existingBlob.Uri);
+                newBlob.StartCopyFromUri(existingBlob.Uri);
+
                 return newBlob.Uri;
             }
+
             return null;
         }
 

--- a/src/Likvido.Azure/Storage/AzureStorageService.cs
+++ b/src/Likvido.Azure/Storage/AzureStorageService.cs
@@ -58,15 +58,15 @@ namespace Likvido.Azure.Storage
         {
             var existingBlob = blobContainerClient.GetBlobClient(tempFileName);
 
-            if (existingBlob?.Exists() == true)
+            if (existingBlob?.Exists() != true)
             {
-                var newBlob = blobContainerClient.GetBlobClient(fileName);
-                newBlob.StartCopyFromUri(existingBlob.Uri);
-
-                return newBlob.Uri;
+                return null;
             }
 
-            return null;
+            var newBlob = blobContainerClient.GetBlobClient(fileName);
+            newBlob.StartCopyFromUri(existingBlob.Uri);
+
+            return newBlob.Uri;
         }
 
         public Uri Set(string key, Stream content, bool overwrite = true, Dictionary<string, string> metadata = null)

--- a/src/Likvido.Azure/Storage/AzureStorageService.cs
+++ b/src/Likvido.Azure/Storage/AzureStorageService.cs
@@ -20,8 +20,8 @@ namespace Likvido.Azure.Storage
         {
             this.storageConfiguration = storageConfiguration;
 
-            var blobStorage = new BlobServiceClient(storageConfiguration.ConnectionString);
-            container = blobStorage.GetBlobContainerClient(containerName);
+            var blobServiceClient = new BlobServiceClient(storageConfiguration.ConnectionString);
+            container = blobServiceClient.GetBlobContainerClient(containerName);
             container.CreateIfNotExists();
             container.SetAccessPolicy(PublicAccessType.Blob);
         }

--- a/src/Likvido.Azure/Storage/IAzureStorageService.cs
+++ b/src/Likvido.Azure/Storage/IAzureStorageService.cs
@@ -13,8 +13,6 @@ namespace Likvido.Azure.Storage
     {
         Task DeleteAsync(Uri uri);
         IEnumerable<Uri> Find(string prefix);
-        Uri Rename(string tempFileName, string fileName);
-        Uri Set(string key, Stream content, bool overwrite = true, Dictionary<string, string> metadata = null);
         Task DeleteAsync(string key);
         Task<MemoryStream> GetAsync(Uri uri);
         Task<MemoryStream> GetAsync(string blobName);

--- a/src/Likvido.Azure/Storage/IAzureStorageService.cs
+++ b/src/Likvido.Azure/Storage/IAzureStorageService.cs
@@ -16,12 +16,10 @@ namespace Likvido.Azure.Storage
         Task DeleteAsync(string key);
         Task<MemoryStream> GetAsync(Uri uri);
         Task<MemoryStream> GetAsync(string blobName);
-        string GetBlobNameFromUri(Uri uri);
         Task<Uri> RenameAsync(string tempFileName, string fileName);
         Task<Uri> SetAsync(string key, Stream content, string friendlyName = null, bool overwrite = true, Dictionary<string, string> metadata = null);
         Task<string> GetBlobSasUriAsync(string url);
         Task<IDictionary<string, string>> GetMetadataAsync(string key);
         Task<IDictionary<string, string>> GetMetadataAsync(Uri uri);
-        Task<IDictionary<string, string>> GetMetadataAsync(BlobClient blob);
     }
 }

--- a/src/Likvido.Azure/Storage/StorageConfiguration.cs
+++ b/src/Likvido.Azure/Storage/StorageConfiguration.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Azure.Storage;
 
 namespace Likvido.Azure.Storage
 {
@@ -6,11 +7,11 @@ namespace Likvido.Azure.Storage
     {
         public string ConnectionString { get; set; }
 
-        public (string StorageAccountName, string StorageAccountKey) GetStorageAccountInfo()
+        internal StorageSharedKeyCredential GetStorageSharedKeyCredential()
         {
             var accountInfo = ConnectionString.Split(';').Where(x => x.Length > 0).Select(x => x.Split(new[] { '=' }, 2)).ToDictionary(x => x[0], x => x[1]);
 
-            return (accountInfo["AccountName"], accountInfo["AccountKey"]);
+            return new StorageSharedKeyCredential(accountInfo["AccountName"], accountInfo["AccountKey"]);
         }
     }
 }

--- a/src/version.props
+++ b/src/version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>2.0.8</Version>
+    <Version>3.0.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Likvido/Likvido.App#19675

Main purpose was to remove the part that set the ACL on the storage account to `Public` for blobs, as that is pretty insane. I also decided the clean up the rest of the class, and removed the non-async overloads to reduce the amount of duplication we have.