### PR TITLE
#19839 - Fixing Aikido warning - upgrading Azure.Core to latest version

### DIFF
--- a/src/Likvido.Azure/Likvido.Azure.csproj
+++ b/src/Likvido.Azure/Likvido.Azure.csproj
@@ -7,7 +7,7 @@
   <Import Project="$(ProjectDir)../version.props" />
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.39.0" />
+    <PackageReference Include="Azure.Core" Version="1.40.0" />
     <PackageReference Include="Azure.Messaging.EventGrid" Version="4.24.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.18.0" />


### PR DESCRIPTION
#19839 - Fixing Aikido warning - upgrading Azure.Core to latest version.

Note: this doesn't fix 100% of the warnings in Aikido. 

The other ones will need to wait for a new version of Microsoft.Data.SqlClient, that hasn't been released yet.