### PR TITLE
Likvido/Likvido.App#23167 - Increasing retries. Changing backoff type to linear.

### DIFF
--- a/src/Likvido.Azure/EventGrid/EventGridService.cs
+++ b/src/Likvido.Azure/EventGrid/EventGridService.cs
@@ -97,9 +97,9 @@ namespace Likvido.Azure.EventGrid
                 .AddRetry(new RetryStrategyOptions<Response>
                 {
                     ShouldHandle = new PredicateBuilder<Response>().Handle<Exception>(),
-                    Delay = TimeSpan.FromSeconds(3),
-                    MaxRetryAttempts = 3,
-                    BackoffType = DelayBackoffType.Exponential,
+                    Delay = TimeSpan.FromSeconds(2),
+                    MaxRetryAttempts = 5,
+                    BackoffType = DelayBackoffType.Linear,
                     OnRetry = args =>
                     {
                         _logger.LogError(args.Outcome.Exception, "Error while publishing events to Event Grid. Retrying in {SleepDuration}. Attempt number {AttemptNumber}", args.RetryDelay.ToString("g"), args.AttemptNumber);

--- a/src/version.props
+++ b/src/version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>3.1.12</Version>
+    <Version>3.1.13</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Likvido/Likvido.App#23167 

The issue here was Azure responded with HTTP 500 errors with messages like:

(it's Microsoft blowing up internally)

---
"An unexpected error has occurred. Please report the x-ms-request-id header value to our forums for assistance or raise a support ticket. Report 'f7d24027-5532-4734-9299-6f6ad3a0fe95:2:3/5/2025 8:34:23 PM (UTC)'"
---

Our retry mechanism is working as designed. I'm just increasing the number of retries and making the backoff linear.




