### PR TITLE
Feature/#24925  likvido azure  pass along the user claims into events and queue messages

### DIFF
--- a/src/Likvido.Azure/DependencyInjection.cs
+++ b/src/Likvido.Azure/DependencyInjection.cs
@@ -5,6 +5,8 @@ using Azure.Storage.Queues;
 using Likvido.Azure.EventGrid;
 using Likvido.Azure.Queue;
 using Likvido.Azure.Storage;
+using Likvido.Identity;
+using Likvido.Identity.PrincipalProviders;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -27,10 +29,13 @@ namespace Likvido.Azure
                     new AzureKeyCredential(eventGridConfiguration.AccessKey));
             });
 
+            services.TryAddNullPrincipalProvider();
+
             services.AddSingleton<IEventGridService>(sp =>
                 new EventGridService(
                     sp.GetRequiredService<EventGridPublisherClient>(),
                     sp.GetRequiredService<ILogger<EventGridService>>(),
+                    sp.GetRequiredService<IPrincipalProvider>(),
                     eventGridConfiguration.Source));
         }
 
@@ -77,7 +82,10 @@ namespace Likvido.Azure
                     .ConfigureOptions(o => o.MessageEncoding = QueueMessageEncoding.Base64);
             });
 
-            services.AddSingleton<IQueueService>(sp => new QueueService(sp.GetRequiredService<QueueServiceClient>(), queueConfiguration.DefaultSource));
+            services.TryAddNullPrincipalProvider();
+
+            services.AddSingleton<IQueueService>(sp => new QueueService(sp.GetRequiredService<QueueServiceClient>(),
+                sp.GetRequiredService<IPrincipalProvider>(), queueConfiguration.DefaultSource));
         }
     }
 }

--- a/src/Likvido.Azure/EventGrid/EventGridService.cs
+++ b/src/Likvido.Azure/EventGrid/EventGridService.cs
@@ -61,7 +61,7 @@ namespace Likvido.Azure.EventGrid
 
                 if (_principalProvider.User != null)
                 {
-                    cloudEvent.ExtensionAttributes.Add("likvidouserclaims", _principalProvider.User.GetAllClaims());
+                    cloudEvent.ExtensionAttributes.Add("likvidouserclaimsstring", _principalProvider.User.GetAllClaimsAsJsonString());
                 }
 
                 var eventSize = GetEventSize(cloudEvent);

--- a/src/Likvido.Azure/EventGrid/EventGridService.cs
+++ b/src/Likvido.Azure/EventGrid/EventGridService.cs
@@ -2,9 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Text.Json;
 using Azure;
 using Azure.Messaging.EventGrid;
+using Likvido.Azure.Extensions;
 using Likvido.CloudEvents;
+using Likvido.Identity.PrincipalProviders;
 using Microsoft.Extensions.Logging;
 using Polly;
 using Polly.Fallback;
@@ -16,12 +19,14 @@ namespace Likvido.Azure.EventGrid
     public class EventGridService : IEventGridService
     {
         private readonly ILogger<EventGridService> _logger;
+        private readonly IPrincipalProvider _principalProvider;
         private readonly string _eventGridSource;
         private readonly EventGridPublisherClient _client;
 
-        public EventGridService(EventGridPublisherClient client, ILogger<EventGridService> logger, string eventGridSource)
+        public EventGridService(EventGridPublisherClient client, ILogger<EventGridService> logger, IPrincipalProvider principalProvider, string eventGridSource)
         {
             _logger = logger;
+            _principalProvider = principalProvider;
             _eventGridSource = eventGridSource;
             _client = client;
         }
@@ -54,6 +59,11 @@ namespace Likvido.Azure.EventGrid
                     ExtensionAttributes = { ["likvidopriority"] = Enum.GetName(typeof(LikvidoPriority), priority) }
                 };
 
+                if (_principalProvider.User != null)
+                {
+                    cloudEvent.ExtensionAttributes.Add("likvidouserclaims", _principalProvider.User.GetAllClaims());
+                }
+
                 var eventSize = GetEventSize(cloudEvent);
 
                 if (currentBatchSize + eventSize > sizeLimit)
@@ -77,12 +87,31 @@ namespace Likvido.Azure.EventGrid
 
         private static int GetEventSize(CloudEvent cloudEvent)
         {
-            // This is a rough estimate of the overhead of the CloudEvent object
-            // It was found via experimentation on calling the actual API with various event sizes
+            // This is a rough estimate of the total CloudEvent size used for batching
+            // Base overhead was found via experimentation on calling the actual API with various event sizes
             const int eventOverhead = 300;
+
+            // Size of the event data payload (BinaryData)
             var actualEventSize = cloudEvent.Data?.ToArray().Length ?? 0;
 
-            return actualEventSize + eventOverhead;
+            // Include the size of extension attributes as they are serialized and transmitted as part of the event
+            var extensionAttributesSize = 0;
+            if (cloudEvent.ExtensionAttributes.Count > 0)
+            {
+                try
+                {
+                    // Estimate by serializing to UTF-8 JSON (close to wire format size)
+                    var bytes = JsonSerializer.SerializeToUtf8Bytes(cloudEvent.ExtensionAttributes);
+                    extensionAttributesSize = bytes.Length;
+                }
+                catch
+                {
+                    // If serialization fails for any reason, fall back to a minimal estimate based on keys/values length
+                    extensionAttributesSize = cloudEvent.ExtensionAttributes.Sum(kvp => (kvp.Key?.Length ?? 0) + (kvp.Value?.ToString()?.Length ?? 0));
+                }
+            }
+
+            return actualEventSize + extensionAttributesSize + eventOverhead;
         }
 
         private async Task SendBatchAsync(List<CloudEvent> batch)

--- a/src/Likvido.Azure/Extensions/PrincipalExtensions.cs
+++ b/src/Likvido.Azure/Extensions/PrincipalExtensions.cs
@@ -1,17 +1,18 @@
 using System.Collections.Generic;
 using System.Security.Claims;
 using System.Security.Principal;
+using System.Text.Json;
 
 namespace Likvido.Azure.Extensions
 {
     public static class PrincipalExtensions
     {
-        public static List<KeyValuePair<string, string>> GetAllClaims(this IPrincipal principal)
+        public static string GetAllClaimsAsJsonString(this IPrincipal principal)
         {
             var result = new List<KeyValuePair<string, string>>();
             if (principal is null)
             {
-                return result;
+                return "[]";
             }
 
             if (principal is ClaimsPrincipal claimsPrincipal)
@@ -28,7 +29,7 @@ namespace Likvido.Azure.Extensions
                 }
             }
 
-            return result;
+            return JsonSerializer.Serialize(result);
         }
     }
 }

--- a/src/Likvido.Azure/Extensions/PrincipalExtensions.cs
+++ b/src/Likvido.Azure/Extensions/PrincipalExtensions.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Security.Principal;
+
+namespace Likvido.Azure.Extensions
+{
+    public static class PrincipalExtensions
+    {
+        public static List<KeyValuePair<string, string>> GetAllClaims(this IPrincipal principal)
+        {
+            var result = new List<KeyValuePair<string, string>>();
+            if (principal is null)
+            {
+                return result;
+            }
+
+            if (principal is ClaimsPrincipal claimsPrincipal)
+            {
+                // Enumerate all claims across all identities
+                foreach (var claim in claimsPrincipal.Claims)
+                {
+                    if (claim is null)
+                    {
+                        continue;
+                    }
+
+                    result.Add(new KeyValuePair<string, string>(claim.Type, claim.Value));
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Likvido.Azure/Likvido.Azure.csproj
+++ b/src/Likvido.Azure/Likvido.Azure.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Azure.Messaging.EventGrid" Version="5.0.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.25.0" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.23.0" />
-    <PackageReference Include="Likvido.CloudEvents" Version="1.1.0" />
+    <PackageReference Include="Likvido.CloudEvents" Version="1.2.0" />
     <PackageReference Include="Likvido.Identity" Version="0.0.3" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.12.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.8" />

--- a/src/Likvido.Azure/Likvido.Azure.csproj
+++ b/src/Likvido.Azure/Likvido.Azure.csproj
@@ -14,10 +14,11 @@
     <PackageReference Include="Azure.Messaging.EventGrid" Version="5.0.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.25.0" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.23.0" />
-    <PackageReference Include="Likvido.CloudEvents" Version="1.0.3" />
+    <PackageReference Include="Likvido.CloudEvents" Version="1.1.0" />
+    <PackageReference Include="Likvido.Identity" Version="0.0.3" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.12.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Polly.Core" Version="8.6.3" />
   </ItemGroup>

--- a/src/Likvido.Azure/Likvido.Azure.csproj
+++ b/src/Likvido.Azure/Likvido.Azure.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.12.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Polly.Core" Version="8.6.3" />
   </ItemGroup>
 

--- a/src/Likvido.Azure/Queue/QueueService.cs
+++ b/src/Likvido.Azure/Queue/QueueService.cs
@@ -77,7 +77,7 @@ namespace Likvido.Azure.Queue
 
             if (_principalProvider.User != null)
             {
-                cloudEvent.LikvidoUserClaims = _principalProvider.User.GetAllClaims();
+                cloudEvent.LikvidoUserClaimsString = _principalProvider.User.GetAllClaimsAsJsonString();
             }
 
             await SendMessageAsync(queueName, cloudEvent, initialVisibilityDelay, timeToLive, cancellationToken).ConfigureAwait(false);

--- a/src/Likvido.Azure/Queue/QueueService.cs
+++ b/src/Likvido.Azure/Queue/QueueService.cs
@@ -8,7 +8,7 @@ using Azure.Storage.Queues;
 using Likvido.Azure.Extensions;
 using Likvido.CloudEvents;
 using Likvido.Identity.PrincipalProviders;
-using Newtonsoft.Json;
+using System.Text.Json;
 using Polly;
 using Polly.Retry;
 
@@ -110,7 +110,7 @@ namespace Likvido.Azure.Queue
                         try
                         {
                             await queue.SendMessageAsync(
-                                    JsonConvert.SerializeObject(message),
+                                    JsonSerializer.Serialize(message),
                                     timeToLive: timeToLive ?? TimeSpan.FromSeconds(-1), // Using -1 means that the message does not expire.
                                     visibilityTimeout: initialVisibilityDelay,
                                     cancellationToken: cancellationToken)

--- a/src/UnitTests/EventGrid/EventGridServiceTests.cs
+++ b/src/UnitTests/EventGrid/EventGridServiceTests.cs
@@ -2,6 +2,7 @@ using Azure;
 using Azure.Messaging;
 using Azure.Messaging.EventGrid;
 using Likvido.Azure.EventGrid;
+using Likvido.Identity.PrincipalProviders;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -20,8 +21,7 @@ public class EventGridServiceTests
     {
         // Arrange
         var mockClient = new Mock<EventGridPublisherClient>();
-        var mockLogger = new Mock<ILogger<EventGridService>>();
-        var service = new EventGridService(mockClient.Object, mockLogger.Object, "fakeSource");
+        var service = new EventGridService(mockClient.Object, Mock.Of<ILogger<EventGridService>>(), Mock.Of<IPrincipalProvider>(), "fakeSource");
         var events = GenerateFakeEvents(eventCount);
 
         // Setup

--- a/src/UnitTests/Extensions/PrincipalExtensionsTests.cs
+++ b/src/UnitTests/Extensions/PrincipalExtensionsTests.cs
@@ -1,0 +1,117 @@
+using System.Security.Claims;
+using System.Security.Principal;
+using Likvido.Azure.Extensions;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Extensions;
+
+public class PrincipalExtensionsTests
+{
+    [Fact]
+    public void GetAllClaims_WhenPrincipalIsNull_ReturnsEmptyList()
+    {
+        // Arrange
+        IPrincipal principal = null!;
+
+        // Act
+        var claims = principal.GetAllClaims();
+
+        // Assert
+        claims.ShouldNotBeNull();
+        claims.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetAllClaims_WhenPrincipalIsNotClaimsPrincipal_ReturnsEmptyList()
+    {
+        // Arrange: create a custom IPrincipal that is NOT a ClaimsPrincipal
+        var identity = new GenericIdentity("user");
+        IPrincipal principal = new NonClaimsPrincipal(identity);
+
+        // Act
+        var claims = principal.GetAllClaims();
+
+        // Assert
+        claims.ShouldNotBeNull();
+        claims.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetAllClaims_WhenSingleIdentity_ReturnsAllClaims()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, "123"),
+            new Claim(ClaimTypes.Name, "Alice"),
+            new Claim("custom", "value")
+        }, "testAuth");
+        IPrincipal principal = new ClaimsPrincipal(identity);
+
+        // Act
+        var claims = principal.GetAllClaims();
+
+        // Assert
+        claims.Count.ShouldBe(3);
+        claims.ShouldContain(kv => kv.Key == ClaimTypes.NameIdentifier && kv.Value == "123");
+        claims.ShouldContain(kv => kv.Key == ClaimTypes.Name && kv.Value == "Alice");
+        claims.ShouldContain(kv => kv.Key == "custom" && kv.Value == "value");
+    }
+
+    [Fact]
+    public void GetAllClaims_WhenMultipleIdentities_AggregatesAllClaims()
+    {
+        // Arrange
+        var identity1 = new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.Email, "a@example.com"),
+            new Claim("scope", "read")
+        }, "auth1");
+
+        var identity2 = new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.Email, "b@example.com"),
+            new Claim("scope", "write")
+        }, "auth2");
+
+        IPrincipal principal = new ClaimsPrincipal(new[] { identity1, identity2 });
+
+        // Act
+        var claims = principal.GetAllClaims();
+
+        // Assert
+        claims.Count.ShouldBe(4);
+        claims.ShouldContain(kv => kv.Key == ClaimTypes.Email && kv.Value == "a@example.com");
+        claims.ShouldContain(kv => kv.Key == "scope" && kv.Value == "read");
+        claims.ShouldContain(kv => kv.Key == ClaimTypes.Email && kv.Value == "b@example.com");
+        claims.ShouldContain(kv => kv.Key == "scope" && kv.Value == "write");
+    }
+
+    [Fact]
+    public void GetAllClaims_WhenDuplicateTypes_IncludesAllOccurrences()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity(new[]
+        {
+            new Claim("role", "admin"),
+            new Claim("role", "editor")
+        }, "auth");
+        IPrincipal principal = new ClaimsPrincipal(identity);
+
+        // Act
+        var claims = principal.GetAllClaims();
+
+        // Assert
+        claims.Count.ShouldBe(2);
+        claims.ShouldContain(kv => kv.Key == "role" && kv.Value == "admin");
+        claims.ShouldContain(kv => kv.Key == "role" && kv.Value == "editor");
+    }
+
+    private sealed class NonClaimsPrincipal : IPrincipal
+    {
+        public IIdentity Identity { get; }
+        public NonClaimsPrincipal(IIdentity identity) => Identity = identity;
+        public bool IsInRole(string role) => false;
+    }
+}


### PR DESCRIPTION
Resolves: Likvido/Likvido.App#24925

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Events and queue messages now include user claim metadata when available, improving traceability.
- Refactor
  - Enhanced event size estimation for batching, improving publishing efficiency and reliability.
- Chores
  - Dependency updates and DI registration to ensure a principal provider is available by default.
- Tests
  - Added tests for claim extraction and updated existing tests to reflect the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->